### PR TITLE
fix: Rename form block to trial-form #15

### DIFF
--- a/blocks/trial-form/trial-form.css
+++ b/blocks/trial-form/trial-form.css
@@ -67,8 +67,8 @@ main .form .highlight {
 }
 
 main .dark .form h3,
-main .dark .form-text-field-wrapper p,
-main .dark .form-submit-message {
+main .dark .form .form-text-field-wrapper p,
+main .dark .form .form-submit-message {
   color: var(--color-white);
 }
 

--- a/blocks/trial-form/trial-form.js
+++ b/blocks/trial-form/trial-form.js
@@ -115,11 +115,12 @@ async function createForm(formURL) {
   return form;
 }
 
-const init = async (el) => {
-  const anchor = el.querySelector('p > a[href$=".json"]');
+const decorate = async (block) => {
+  block.classList.add('form');
+  const anchor = block.querySelector('p > a[href$=".json"]');
   if (anchor) {
     anchor.parentElement.replaceWith(await createForm(anchor.href));
   }
 };
 
-export default init;
+export default decorate;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -59,6 +59,5 @@ const miloLibs = setLibs(LIBS);
 (async function loadPage() {
   const { loadArea, setConfig } = await import(`${miloLibs}/utils/utils.js`);
   const config = setConfig({ ...CONFIG, miloLibs });
-  console.log(config);
   await loadArea();
 }());

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -18,8 +18,8 @@ const CONFIG = {
   imsClientId: '',
   locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } },
   geoRouting: 'off',
-  productionDomain: 'aem-trials.adobe.com',
-  prodDomains: ['aem-trials.adobe.com'],
+  productionDomain: 'aem-trial.adobe.com',
+  prodDomains: ['aem-trial.adobe.com'],
   useDotHtml: true,
 };
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -58,6 +58,6 @@ const miloLibs = setLibs(LIBS);
 
 (async function loadPage() {
   const { loadArea, setConfig } = await import(`${miloLibs}/utils/utils.js`);
-  const config = setConfig({ ...CONFIG, miloLibs });
+  setConfig({ ...CONFIG, miloLibs });
   await loadArea();
 }());


### PR DESCRIPTION

Fix #15

## Test URLs:
- Before: https://main--aem-trials--adobe.hlx.page/headless
- After: https://form-block-name--aem-trials--adobe.hlx.page/headless

## Changes
- milo now has its own `form` block
- renaming the aem trials form block to avoid collisions
